### PR TITLE
Handle logs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 
 [deps]
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
+Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 
 [compat]
 PowerModels = "0.18"

--- a/src/PWF.jl
+++ b/src/PWF.jl
@@ -2,6 +2,21 @@ module PWF
 
 # using packages
 using PowerModels
+using Memento
+
+# setting up Memento
+const _LOGGER = Memento.getlogger(@__MODULE__)
+
+__init__() = Memento.register(_LOGGER)
+
+function silence()
+    Memento.info(_LOGGER, "Suppressing information and warning messages for the rest of this session.  Use the Memento package for more fine-grained control of logging.")
+    Memento.setlevel!(Memento.getlogger(PWF), "error")
+end
+
+function logger_config!(level)
+    Memento.config!(Memento.getlogger("PWF"), level)
+end
 
 # include PWF parser file
 include("pwf2dict.jl")

--- a/src/pwf2dict.jl
+++ b/src/pwf2dict.jl
@@ -496,9 +496,9 @@ function _parse_line_element!(data::Dict{String, Any}, line::String, section::Ab
             else
                 data[field] = element
             end
-        catch
+        catch message
             if !_needs_default(element)
-                Memento.warn(_LOGGER, "Could not parse $element to $dtype inside $section section, setting it as a String")
+                throw(Memento.error(_LOGGER, "Parsing error at section $section: $field should be of type $dtype, received $element"))
             end
             data[field] = element
         end
@@ -519,9 +519,9 @@ function _parse_line_element!(data::Dict{String, Any}, lines::Vector{String}, se
                 if mn_type != String && mn_type != Char
                     try
                         data[line[k]] = parse(mn_type, line[v])
-                    catch
+                    catch message
                         if !_needs_default(line[v])
-                            Memento.warn(_LOGGER, "Could not parse $(line[v]) to $mn_type, setting it as a String")
+                            throw(Memento.error(_LOGGER, "Parsing error at section $section: $field should be of type $dtype, received $element"))
                         end
                         !_needs_default(line[k]) ? data[line[k]] = line[v] : nothing
                     end

--- a/src/pwf2dict.jl
+++ b/src/pwf2dict.jl
@@ -498,7 +498,7 @@ function _parse_line_element!(data::Dict{String, Any}, line::String, section::Ab
             end
         catch
             if !_needs_default(element)
-                @warn "Could not parse $element to $dtype inside $section section, setting it as a String"
+                Memento.warn(_LOGGER, "Could not parse $element to $dtype inside $section section, setting it as a String")
             end
             data[field] = element
         end
@@ -521,7 +521,7 @@ function _parse_line_element!(data::Dict{String, Any}, lines::Vector{String}, se
                         data[line[k]] = parse(mn_type, line[v])
                     catch
                         if !_needs_default(line[v])
-                            @warn "Could not parse $(line[v]) to $mn_type, setting it as a String"
+                            Memento.warn(_LOGGER, "Could not parse $(line[v]) to $mn_type, setting it as a String")
                         end
                         !_needs_default(line[k]) ? data[line[k]] = line[v] : nothing
                     end
@@ -606,7 +606,7 @@ function _parse_section!(data::Dict{String, Any}, section_lines::Vector{String})
         _parse_divided_section!(section_data, section_lines, section)
 
     else
-        @warn "Currently there is no support for $section parsing"
+        Memento.warn(_LOGGER, "Currently there is no support for $section parsing")
         section_data = nothing
     end
     data[section] = section_data
@@ -617,11 +617,11 @@ _needs_default(ch::Char) = ch == ' '
 
 function _populate_defaults!(pwf_data::Dict{String, Any})
 
-    @warn "Populating defaults"
+    Memento.info(_LOGGER, "Populating defaults")
 
     for (section, section_data) in pwf_data
         if !haskey(_pwf_defaults, section)
-            @warn "Parser doesn't have default values for section $(section)."
+            Memento.warn(_LOGGER, "Parser doesn't have default values for section $(section)")
         else
             if section in keys(_pwf_dtypes)
                 _populate_section_defaults!(pwf_data, section, section_data)

--- a/src/pwf2dict.jl
+++ b/src/pwf2dict.jl
@@ -6,7 +6,7 @@
 
 # This parser was develop using ANAREDE v09 user manual
 
-const _fban_1_dtypes = [("FROM BUS", Int64, 1:5), ("OPERATION", Int64, 7),
+const _fban_1_dtypes = [("FROM BUS", Int64, 1:5), ("OPERATION", Char, 7),
     ("TO BUS", Int64, 9:13), ("CIRCUIT", Int64, 15:16), ("CONTROL MODE", Char, 18),
     ("MINIMUM VOLTAGE", Float64, 20:23, 20), ("MAXIMUM VOLTAGE", Float64, 25:28, 25),
     ("CONTROLLED BUS", Int64, 30:34), ("INITIAL REACTIVE INJECTION", Float64, 36:41),
@@ -34,7 +34,7 @@ const _divided_sections = Dict("DBSH" => _dbsh_dtypes,
 """
 A list of data file sections in the order that they appear in a PWF file
 """
-const _dbar_dtypes = [("NUMBER", Int64, 1:5), ("OPERATION", Int64, 6), 
+const _dbar_dtypes = [("NUMBER", Int64, 1:5), ("OPERATION", Char, 6), 
     ("STATUS", Char, 7), ("TYPE", Int64, 8), ("BASE VOLTAGE GROUP", String, 9:10),
     ("NAME", String, 11:22), ("VOLTAGE LIMIT GROUP", String, 23:24),
     ("VOLTAGE", Float64, 25:28, 25), ("ANGLE", Float64, 29:32),
@@ -51,7 +51,7 @@ const _dbar_dtypes = [("NUMBER", Int64, 1:5), ("OPERATION", Int64, 6),
     ("AGGREGATOR 9", Int64, 106:108), ("AGGREGATOR 10", Int64, 109:111)]
 
 const _dlin_dtypes = [("FROM BUS", Int64, 1:5), ("OPENING FROM BUS", Char, 6),
-    ("OPERATION", Int64, 8), ("OPENING TO BUS", Char, 10), ("TO BUS", Int64, 11:15),
+    ("OPERATION", Char, 8), ("OPENING TO BUS", Char, 10), ("TO BUS", Int64, 11:15),
     ("CIRCUIT", Int64, 16:17), ("STATUS", Char, 18), ("OWNER", Char, 19),
     ("RESISTANCE", Float64, 21:26, 24), ("REACTANCE", Float64, 27:32, 30),
     ("SHUNT SUSCEPTANCE", Float64, 33:38, 35), ("TAP", Float64, 39:43, 40),
@@ -80,26 +80,26 @@ const _dger_dtypes = [("NUMBER", Int, 1:5), ("OPERATION", Char, 7),
     ("ROTOR SERVICE FACTOR", Float64, 46:49), ("CHARGE ANGLE", Float64, 51:54),
     ("MACHINE REACTANCE", Float64, 56:60), ("NOMINAL APPARENT POWER", Float64, 62:66)]
 
-const _dshl_dtypes = [("FROM BUS", Int64, 1:5), ("OPERATION", Int64, 7),
+const _dshl_dtypes = [("FROM BUS", Int64, 1:5), ("OPERATION", Char, 7),
     ("TO BUS", Int64, 10:14), ("CIRCUIT", Int64, 15:16), ("SHUNT FROM", Float64, 18:23),
     ("SHUNT TO", Float64, 24:29), ("STATUS FROM", String, 31:32), ("STATUS TO", String, 34:35)]
 
-const _dcba_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Int64, 6), ("TYPE", Int64, 8),
+const _dcba_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Char, 6), ("TYPE", Int64, 8),
     ("POLARITY", Char, 9), ("NAME", String, 10:21), ("VOLTAGE LIMIT GROUP", String, 22:23),
     ("VOLTAGE", Float64, 24:28), ("GROUND ELECTRODE", Float64, 67:71), ("DC LINK", Int64, 72:75)]
 
-const _dcli_dtypes = [("FROM BUS", Int64, 1:4), ("OPERATION", Int64, 6), ("TO BUS", Int64, 9:12),
+const _dcli_dtypes = [("FROM BUS", Int64, 1:4), ("OPERATION", Char, 6), ("TO BUS", Int64, 9:12),
     ("CIRCUIT", Int64, 13:14), ("OWNER", Char, 16), ("RESISTANCE", Float64, 18:23),
     ("INDUCTANCE", Float64, 24:29), ("CAPACITY", Float64, 61:64)]
 
-const _dcnv_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Int64, 6), ("AC BUS", Int64, 8:12),
+const _dcnv_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Char, 6), ("AC BUS", Int64, 8:12),
     ("DC BUS", Int64, 14:17), ("NEUTRAL BUS", Int64, 19:22), ("OPERATION MODE", Char, 24),
     ("BRIDGES", Int64, 26), ("CURRENT", Float64, 28:32), ("COMMUTATION REACTANCE", Float64, 34:38),
     ("SECONDARY VOLTAGE", Float64, 40:44), ("TRANSFORMER POWER", Float64, 46:50),
     ("REACTOR RESISTANCE", Float64, 52:56), ("REACTOR INDUCTANCE", Float64, 58:62),
     ("CAPACITANCE", Float64, 64:68), ("FREQUENCY", Float64, 70:71)]
 
-const _dccv_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Int64, 6), ("LOOSENESS", Char, 8),
+const _dccv_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Char, 6), ("LOOSENESS", Char, 8),
     ("INVERTER CONTROL MODE", Char, 9), ("CONVERTER CONTROL TYPE", Char, 10),
     ("SPECIFIED VALUE", Float64, 12:16), ("CURRENT MARGIN", Float64,18:22),
     ("MAXIMUM OVERCURRENT", Float64, 24:28), ("CONVERTER ANGLE", Float64, 30:34),
@@ -109,7 +109,7 @@ const _dccv_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Int64, 6), ("LOOSENE
     ("MINIMUM DC VOLTAGE FOR POWER CONTROL", Float64, 63:66, 63),
     ("TAP HI MVAR MODE", Float64, 68:72), ("TAP REDUCED VOLTAGE MODE", Float64, 74:78)]
 
-const _delo_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Int64, 6), ("VOLTAGE", Float64, 8:12),
+const _delo_dtypes = [("NUMBER", Int64, 1:4), ("OPERATION", Char, 6), ("VOLTAGE", Float64, 8:12),
     ("BASE", Float64, 14:18), ("NAME", String, 20:39), ("HI MVAR MODE", Char, 41), ("STATUS", Char, 43)]
 
 const _dcer_dtypes = [("BUS", Int, 1:5), ("OPERATION", Char, 7), ("GROUP", Int64, 9:10),

--- a/src/pwf2pm/branch.jl
+++ b/src/pwf2pm/branch.jl
@@ -171,7 +171,7 @@ function _pwf2pm_DCSC_branch!(pm_data::Dict, pwf_data::Dict, branch::Dict; add_c
 
     rep = findall(x -> x["f_bus"] == sub_data["f_bus"] && x["t_bus"] == sub_data["t_bus"] && x["circuit"] == sub_data["circuit"], pm_data["branch"])
     if length(rep) > 0
-        @warn "Branch from $(sub_data["f_bus"]) to $(sub_data["t_bus"]) in circuit $(sub_data["circuit"]) is duplicated"
+        Memento.warn(_LOGGER,  "Branch from $(sub_data["f_bus"]) to $(sub_data["t_bus"]) in circuit $(sub_data["circuit"]) is duplicated")
     end
     idx = string(sub_data["index"])
     pm_data["branch"][idx] = sub_data

--- a/src/pwf2pm/bus.jl
+++ b/src/pwf2pm/bus.jl
@@ -108,9 +108,9 @@ end
 function _pwf2pm_bus!(pm_data::Dict, pwf_data::Dict; add_control_data::Bool=false)
 
     dict_dglt = haskey(pwf_data, "DGLT") ? _create_dict_dglt(pwf_data["DGLT"]) : nothing
-    isa(dict_dglt, Dict) && length(dict_dglt) == 1 ? @warn("Only one limit voltage group definded, each bus will be considered as part of the group $(pwf_data["DGLT"]["1"]["GROUP"]), regardless of its defined group") : nothing
+    isa(dict_dglt, Dict) && length(dict_dglt) == 1 ? Memento.warn(_LOGGER, "Only one limit voltage group definded, each bus will be considered as part of the group $(pwf_data["DGLT"]["1"]["GROUP"]), regardless of its defined group") : nothing
     dict_dgbt = haskey(pwf_data, "DGBT") ? _create_dict_dgbt(pwf_data["DGBT"]) : nothing
-    isa(dict_dgbt, Dict) && length(dict_dgbt) == 1 ? @warn("Only one base voltage group definded, each bus will be considered as part of the group $(pwf_data["DGBT"]["1"]["GROUP"]), regardless of its defined group") : nothing
+    isa(dict_dgbt, Dict) && length(dict_dgbt) == 1 ? Memento.warn(_LOGGER, "Only one base voltage group definded, each bus will be considered as part of the group $(pwf_data["DGBT"]["1"]["GROUP"]), regardless of its defined group") : nothing
 
     pm_data["bus"] = Dict{String, Any}()
     if haskey(pwf_data, "DBAR")

--- a/src/pwf2pm/correct/anarede.jl
+++ b/src/pwf2pm/correct/anarede.jl
@@ -82,8 +82,8 @@ function _pwf2pm_corrections_PQ!(pm_data::Dict, software::ANAREDE)
                 # sum load power with the negative of generator power
                 pm_data["load"][load_key[1]]["pd"] += - Pg
                 pm_data["load"][load_key[1]]["qd"] += - Qg                 
-                @warn "Active generator with QMIN = QMAX = 0 found in PQ bus $i. Adding generator power " *
-                            "to load power and changing generator status to off."
+                Memento.warn(_LOGGER, "Active generator with QMIN = QMAX = 0 found in PQ bus $i. Adding generator power " *
+                            "to load power and changing generator status to off")
             end
         end
     end

--- a/src/pwf2pm/correct/organon.jl
+++ b/src/pwf2pm/correct/organon.jl
@@ -12,7 +12,7 @@ function _pwf2pm_corrections_PV!(pm_data::Dict, pwf_data::Dict, software::Organo
                 if isempty(load_from_bus(pm_data, parse(Int, i))) 
                     _pwf2pm_load!(pm_data, pwf_data, parse(Int,i))
                 end
-                @warn "Active generator with QMIN = QMAX found in a PV bus number $i. Changing bus type from PV to PQ."
+                Memento.warn(_LOGGER,  "Active generator with QMIN = QMAX found in a PV bus number $i. Changing bus type from PV to PQ")
             end
         end
     end
@@ -32,7 +32,7 @@ function _pwf2pm_corrections_PQ!(pm_data::Dict, software::Organon)
             if !isempty(gen_keys_case1)
                 # change bus type to PV
                 bus["bus_type"] = bus_type_str_to_num["PV"]
-                @warn "Active generator with QMIN < QMAX found in a PQ bus. Changing bus $i type to PV."
+                Memento.warn(_LOGGER,  "Active generator with QMIN < QMAX found in a PQ bus. Changing bus $i type to PV")
             elseif !isempty(gen_keys_case2)
                 # change generator status to off and sum load power with gen power
                 Pg, Qg = sum_generators_power_and_turn_off(pm_data, gen_keys_case2)
@@ -41,8 +41,8 @@ function _pwf2pm_corrections_PQ!(pm_data::Dict, software::Organon)
                 # sum load power with the negative of generator power
                 pm_data["load"][load_key[1]]["pd"] += - Pg
                 pm_data["load"][load_key[1]]["qd"] += - Qg                 
-                @warn "Active generator with QMIN = QMAX found in PQ bus $i. Adding generator power " *
-                    "to load power and changing generator status to off."
+                Memento.warn(_LOGGER,  "Active generator with QMIN = QMAX found in PQ bus $i. Adding generator power " *
+                    "to load power and changing generator status to off")
             end
         end
     end

--- a/src/pwf2pm/dcline.jl
+++ b/src/pwf2pm/dcline.jl
@@ -52,8 +52,8 @@ function _pwf2pm_dcline!(pm_data::Dict, pwf_data::Dict, link::Dict)
     # pf = mdc == 'P' ? abs(setvl[1]) : mdc == 'C' ? - abs(setvl[1] / vschd[1] / 1000) : 0
     # pt = mdc == 'P' ? - abs(setvl[2]) : mdc == 'C' ? abs(setvl[2] / vschd[2] / 1000) : 0
 
-    pf = mdc == 'P' ? abs(setvl) : @error("The formulation is prepared only for power control")
-    pt = mdc == 'P' ? - abs(setvl) + loss : @error("The formulation is prepared only for power control")
+    pf = mdc == 'P' ? abs(setvl) : Memento.error(_LOGGER, "The formulation is prepared only for power control")
+    pt = mdc == 'P' ? - abs(setvl) + loss : Memento.error(_LOGGER, "The formulation is prepared only for power control")
 
     sub_data["f_bus"] = dict_dcnv[rect]["AC BUS"]
     sub_data["t_bus"] = dict_dcnv[inv]["AC BUS"]
@@ -83,7 +83,7 @@ function _pwf2pm_dcline!(pm_data::Dict, pwf_data::Dict, link::Dict)
             push!(anmn, angle)
         else
             push!(anmn, 0)
-            @warn("$key outside reasonable limits, setting to 0 degress")
+            Memento.warn(_LOGGER, "$key outside reasonable limits, setting to 0 degress")
         end
     end
 
@@ -114,7 +114,7 @@ function _pwf2pm_dcline!(pm_data::Dict, pwf_data::Dict)
     pm_data["dcline"] = Dict{String, Any}()
 
     if !(haskey(pwf_data, "DCBA") && haskey(pwf_data, "DCLI") && haskey(pwf_data, "DCNV") && haskey(pwf_data, "DCCV") && haskey(pwf_data, "DELO"))
-        @warn("DC line will not be parsed due to the absence of at least one those sections: DCBA, DCLI, DCNV, DCCV, DELO")
+        Memento.warn(_LOGGER, "DC line will not be parsed due to the absence of at least one those sections: DCBA, DCLI, DCNV, DCCV, DELO")
         return
     end
     @assert length(pwf_data["DCBA"]) == 4*length(pwf_data["DCLI"]) == 2*length(pwf_data["DCNV"]) == 2*length(pwf_data["DCCV"]) == 4*length(pwf_data["DELO"])

--- a/src/pwf2pm/gen.jl
+++ b/src/pwf2pm/gen.jl
@@ -60,7 +60,7 @@ end
 function _pwf2pm_generator!(pm_data::Dict, pwf_data::Dict)
 
     if !haskey(pwf_data, "DGER")
-        @warn("DGER not found, setting pmin as 0.0 MW and pmax as 99999.0 MW")
+        Memento.warn(_LOGGER, "DGER not found, setting pmin as 0.0 MW and pmax as 99999.0 MW")
     end
 
     pm_data["gen"] = Dict{String, Any}()

--- a/test/test_pwf.jl
+++ b/test/test_pwf.jl
@@ -2,21 +2,21 @@
     @testset "Intermediary functions" begin
         file = open(joinpath(@__DIR__,"data/pwf/test_system.pwf"))
 
-        sections = PWF._split_sections(file)
-        @test isa(sections, Vector{Vector{String}})
+        file_lines, sections = PWF._split_sections(file)
+        @test isa(file_lines, Vector{String})
+        @test isa(sections, Dict{String, Vector{Int64}})
         @test length(sections) == 5
-        @test sections[1][1] == "TITU"
 
         data = Dict{String, Any}()
-        PWF._parse_section!(data, sections[1])
+        PWF._parse_section!(data, "TITU", sections["TITU"], file_lines)
         @test haskey(data, "TITU")
-        PWF._parse_section!(data, sections[2])
+        PWF._parse_section!(data, "DOPC IMPR", sections["DOPC IMPR"], file_lines)
         @test haskey(data, "DOPC IMPR")
-        PWF._parse_section!(data, sections[3])
+        PWF._parse_section!(data, "DCTE", sections["DCTE"], file_lines)
         @test haskey(data, "DCTE")
-        PWF._parse_section!(data, sections[4])
+        PWF._parse_section!(data, "DBAR", sections["DBAR"], file_lines)
         @test haskey(data, "DBAR")
-        PWF._parse_section!(data, sections[5])
+        PWF._parse_section!(data, "DLIN", sections["DLIN"], file_lines)
         @test haskey(data, "DLIN")
     end
 


### PR DESCRIPTION
- Add Memento to handle logs
- Throw an error instead of a warning when an element from the wrong type is read in the PWF file
- Always read field 'OPERATION' as Char, in order to avoid the error mentioned in #28 
- New parsing method, reading the PWF file based on line indexes
- Inform the user in which line errors are occurring, using the new parsing method
- Adjust tests to the new parsing method